### PR TITLE
feat: add health check to ecs container and enable execute command

### DIFF
--- a/skeleton/templates/cdk/src/api-stack.ts.mustache
+++ b/skeleton/templates/cdk/src/api-stack.ts.mustache
@@ -64,6 +64,7 @@ export class ApiStack extends Stack {
                 instanceType: InstanceType.of(InstanceClass.BURSTABLE3, InstanceSize.MEDIUM),
                 autoMinorVersionUpgrade: true,
                 allowMajorVersionUpgrade: true,
+                enablePerformanceInsights: true,
             }),
             defaultDatabaseName: "api",
             backup: {

--- a/skeleton/templates/cdk/src/api-stack.ts.mustache
+++ b/skeleton/templates/cdk/src/api-stack.ts.mustache
@@ -150,6 +150,14 @@ export class ApiStack extends Stack {
             // than assigning a NAT gateway. In a large project, consider moving the tasks into a private subnet with
             // egress instead and enable NAT gateway.
             taskSubnets: { subnetType: SubnetType.PUBLIC },
+            healthCheck: {
+                command: ['CMD-SHELL', 'busybox wget -O /dev/null -T 5 http://127.0.0.1:80/health || exit 1'],
+                startPeriod: Duration.seconds(10),
+                timeout: Duration.seconds(6),
+                retries: 3,
+                interval: Duration.seconds(30),
+            },
+            enableExecuteCommand: true,
             assignPublicIp: true,
             publicLoadBalancer: true,
             healthCheckGracePeriod: Duration.seconds(10),


### PR DESCRIPTION
In addition to the health check I added enableExecuteCommand that lets you execute commands in the ecs container including an interactive shell.  I found it useful for troubleshooting the health check.

aws ecs execute-command  \
    --region us-east-1 \
    --cluster some-client-api-uat-service-ClusterEB0386A7-tfhRT4sSokEF \
    --task 1234567890asdf \
    --container app \
    --command "/bin/sh" \
    --interactive