### PR TITLE
feat: make ALB dual stack and add an access log for the ALB

### DIFF
--- a/skeleton/packages/cdk/src/api-stack.ts.liquid
+++ b/skeleton/packages/cdk/src/api-stack.ts.liquid
@@ -146,7 +146,7 @@ export class ApiStack extends Stack {
             sslPolicy: SslPolicy.RECOMMENDED_TLS,
             ipAddressType: IpAddressType.DUAL_STACK,
         });
-        
+
         const lbLogsBucket = new Bucket(this, "LBLogsBucket", {
             blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
             minimumTLSVersion: 1.2,
@@ -154,12 +154,13 @@ export class ApiStack extends Stack {
             encryption: BucketEncryption.S3_MANAGED,
             lifecycleRules: [
                 {
-                    expiration: Duration.days(60),
+                    // Setting to something longer then 30 days might make GDPR compliance more complex
+                    expiration: Duration.days(28),
                 },
             ],
-          });
+        });
 
-          albService.loadBalancer.logAccessLogs(lbLogsBucket, "api");
+        albService.loadBalancer.logAccessLogs(lbLogsBucket, "api");
 
         albService.loadBalancer.setAttribute('routing.http.drop_invalid_header_fields.enabled', 'true');
         albService.loadBalancer.setAttribute('routing.http.desync_mitigation_mode', 'defensive');

--- a/skeleton/packages/cdk/src/api-stack.ts.liquid
+++ b/skeleton/packages/cdk/src/api-stack.ts.liquid
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { Duration, Stack, type StackProps } from "aws-cdk-lib";
 import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
-import { SslPolicy } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { IpAddressType, SslPolicy } from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { RetentionDays } from "aws-cdk-lib/aws-logs";
 import {
     type CfnVPCCidrBlock,
@@ -22,6 +22,7 @@ import {
     DatabaseClusterEngine,
 } from "aws-cdk-lib/aws-rds";
 import { ClusterInstance } from "aws-cdk-lib/aws-rds";
+import { BlockPublicAccess, Bucket, BucketEncryption, HttpMethods } from "aws-cdk-lib/aws-s3";
 import type { Construct } from "constructs";
 {%- if features contains "app-config" %}
 import { AppConfig } from "./app-config.js";
@@ -143,7 +144,22 @@ export class ApiStack extends Stack {
             publicLoadBalancer: true,
             healthCheckGracePeriod: Duration.seconds(10),
             sslPolicy: SslPolicy.RECOMMENDED_TLS,
+            ipAddressType: IpAddressType.DUAL_STACK,
         });
+        
+        const lbLogsBucket = new Bucket(this, "LBLogsBucket", {
+            blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+            minimumTLSVersion: 1.2,
+            enforceSSL: true,
+            encryption: BucketEncryption.S3_MANAGED,
+            lifecycleRules: [
+                {
+                    expiration: Duration.days(60),
+                },
+            ],
+          });
+
+          albService.loadBalancer.logAccessLogs(lbLogsBucket, "api");
 
         albService.loadBalancer.setAttribute('routing.http.drop_invalid_header_fields.enabled', 'true');
         albService.loadBalancer.setAttribute('routing.http.desync_mitigation_mode', 'defensive');

--- a/skeleton/packages/zoom-log-error-notifications/src/handler.ts
+++ b/skeleton/packages/zoom-log-error-notifications/src/handler.ts
@@ -106,7 +106,7 @@ export const main = async (event: CloudWatchLogsEvent): Promise<void> => {
         if (
             message?.error &&
             typeof message.error.name === "string" &&
-            message.error.message === "string"
+            typeof message.error.message === "string"
         ) {
             body.push({
                 type: "message",


### PR DESCRIPTION
- This will make the ALB dual stack.  Despite being in a dual stack VPC it still defaults to ipv4 only.
- this will create a bucket called LBLogsBucket that has public access blocked, encryption enabled, and requires tls.
- this will automatically create a bucket policy to allow the ALB to call put object on the bucket
- finally it will tell the alb to log into the api folder in the LBLogsBucket bucket.